### PR TITLE
feat: prompt user to save settings changes before navigating back

### DIFF
--- a/lib/pages/auto_clock_settings_page.dart
+++ b/lib/pages/auto_clock_settings_page.dart
@@ -10,42 +10,65 @@ class AutoClockSettingsPage extends StatefulWidget {
 
 class _AutoClockSettingsPageState extends State<AutoClockSettingsPage> {
   final AutoClockService _autoClockService = AutoClockService();
-  
+
   bool _isLoading = true;
+  // Current settings
   bool _clockInEnabled = false;
   bool _clockOutEnabled = false;
   TimeOfDay _clockInTime = const TimeOfDay(hour: 9, minute: 20);
   TimeOfDay _clockOutTime = const TimeOfDay(hour: 18, minute: 30);
-  
+
+  // Original settings to track changes
+  late bool _originalClockInEnabled;
+  late bool _originalClockOutEnabled;
+  late TimeOfDay _originalClockInTime;
+  late TimeOfDay _originalClockOutTime;
+
   @override
   void initState() {
     super.initState();
     _loadSettings();
   }
-  
+
   Future<void> _loadSettings() async {
     final settings = await _autoClockService.getAutoClockSettings();
-    
+
     setState(() {
+      // Set current values
       _clockInEnabled = settings['clockInEnabled'];
       _clockOutEnabled = settings['clockOutEnabled'];
       _clockInTime = TimeOfDay(
-        hour: settings['clockInHour'], 
+        hour: settings['clockInHour'],
         minute: settings['clockInMinute']
       );
       _clockOutTime = TimeOfDay(
         hour: settings['clockOutHour'], 
         minute: settings['clockOutMinute']
       );
+
+      // Store original values
+      _originalClockInEnabled = _clockInEnabled;
+      _originalClockOutEnabled = _clockOutEnabled;
+      _originalClockInTime = _clockInTime;
+      _originalClockOutTime = _clockOutTime;
+
       _isLoading = false;
     });
   }
-  
+
+  // Check if settings have changed
+  bool _hasChanges() {
+    return _clockInEnabled != _originalClockInEnabled ||
+        _clockOutEnabled != _originalClockOutEnabled ||
+        _clockInTime != _originalClockInTime ||
+        _clockOutTime != _originalClockOutTime;
+  }
+
   Future<void> _saveSettings() async {
     setState(() {
       _isLoading = true;
     });
-    
+
     await _autoClockService.saveAutoClockSettings(
       clockInEnabled: _clockInEnabled,
       clockOutEnabled: _clockOutEnabled,
@@ -54,213 +77,259 @@ class _AutoClockSettingsPageState extends State<AutoClockSettingsPage> {
       clockOutHour: _clockOutTime.hour,
       clockOutMinute: _clockOutTime.minute,
     );
-    
+
     setState(() {
+      _originalClockInEnabled = _clockInEnabled;
+      _originalClockOutEnabled = _clockOutEnabled;
+      _originalClockInTime = _clockInTime;
+      _originalClockOutTime = _clockOutTime;
       _isLoading = false;
     });
-    
+
     if (context.mounted) {
       ScaffoldMessenger.of(context).showSnackBar(
         const SnackBar(content: Text('自動打卡設置已保存')),
       );
-      Navigator.of(context).pop(true);
     }
   }
-  
+
+  Future<bool> _onWillPop() async {
+    if (!_hasChanges()) {
+      return true; // No changes, allow pop
+    }
+
+    final shouldSave = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('未保存的更動'),
+        content: const Text('您的自動打卡設定已被修改，是否要儲存變更？'),
+        actions: <Widget>[
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(false), // No
+            child: const Text('否'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(true), // Yes
+            child: const Text('是'),
+          ),
+        ],
+      ),
+    );
+
+    if (shouldSave == null) return false; // Dialog dismissed, don't pop
+
+    if (shouldSave) {
+      await _saveSettings();
+    }
+
+    return true; // Allow pop
+  }
+
   Future<void> _selectClockInTime() async {
     final TimeOfDay? selectedTime = await showTimePicker(
       context: context,
       initialTime: _clockInTime,
     );
-    
+
     if (selectedTime != null) {
       setState(() {
         _clockInTime = selectedTime;
       });
     }
   }
-  
+
   Future<void> _selectClockOutTime() async {
     final TimeOfDay? selectedTime = await showTimePicker(
       context: context,
       initialTime: _clockOutTime,
     );
-    
+
     if (selectedTime != null) {
       setState(() {
         _clockOutTime = selectedTime;
       });
     }
   }
-  
+
   String _formatTimeOfDay(TimeOfDay time) {
     final hour = time.hour.toString().padLeft(2, '0');
     final minute = time.minute.toString().padLeft(2, '0');
     return '$hour:$minute';
   }
-  
+
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(
-        title: const Text('自動打卡設置'),
-      ),
-      body: _isLoading
-          ? const Center(child: CircularProgressIndicator())
-          : SingleChildScrollView(
-              padding: const EdgeInsets.all(16.0),
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  const Text(
-                    '自動打卡設置',
-                    style: TextStyle(fontSize: 20, fontWeight: FontWeight.bold),
-                  ),
-                  const SizedBox(height: 8),
-                  const Text(
-                    '在指定時間自動發送打卡請求，即使應用程序未運行也能正常工作',
-                    style: TextStyle(color: Colors.grey),
-                  ),
-                  const SizedBox(height: 24),
-                  
-                  // 上班打卡設置
-                  const Text(
-                    '上班打卡',
-                    style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
-                  ),
-                  const SizedBox(height: 8),
-                  Card(
-                    child: Padding(
-                      padding: const EdgeInsets.all(16.0),
-                      child: Column(
-                        children: [
-                          SwitchListTile(
-                            title: const Text('啟用自動上班打卡'),
-                            value: _clockInEnabled,
-                            onChanged: (value) {
-                              setState(() {
-                                _clockInEnabled = value;
-                              });
-                            },
-                          ),
-                          const Divider(),
-                          ListTile(
-                            title: const Text('上班打卡時間'),
-                            trailing: Text(
-                              _formatTimeOfDay(_clockInTime),
-                              style: const TextStyle(
-                                fontSize: 16,
-                                fontWeight: FontWeight.bold,
-                              ),
-                            ),
-                            onTap: _selectClockInTime,
-                            enabled: _clockInEnabled,
-                          ),
-                        ],
-                      ),
+    return WillPopScope(
+      onWillPop: _onWillPop,
+      child: Scaffold(
+        appBar: AppBar(
+          title: const Text('自動打卡設置'),
+        ),
+        body: _isLoading
+            ? const Center(child: CircularProgressIndicator())
+            : SingleChildScrollView(
+                padding: const EdgeInsets.all(16.0),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    const Text(
+                      '自動打卡設置',
+                      style:
+                          TextStyle(fontSize: 20, fontWeight: FontWeight.bold),
                     ),
-                  ),
-                  const SizedBox(height: 24),
-                  
-                  // 下班打卡設置
-                  const Text(
-                    '下班打卡',
-                    style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
-                  ),
-                  const SizedBox(height: 8),
-                  Card(
-                    child: Padding(
-                      padding: const EdgeInsets.all(16.0),
-                      child: Column(
-                        children: [
-                          SwitchListTile(
-                            title: const Text('啟用自動下班打卡'),
-                            value: _clockOutEnabled,
-                            onChanged: (value) {
-                              setState(() {
-                                _clockOutEnabled = value;
-                              });
-                            },
-                          ),
-                          const Divider(),
-                          ListTile(
-                            title: const Text('下班打卡時間'),
-                            trailing: Text(
-                              _formatTimeOfDay(_clockOutTime),
-                              style: const TextStyle(
-                                fontSize: 16,
-                                fontWeight: FontWeight.bold,
-                              ),
-                            ),
-                            onTap: _selectClockOutTime,
-                            enabled: _clockOutEnabled,
-                          ),
-                        ],
-                      ),
+                    const SizedBox(height: 8),
+                    const Text(
+                      '在指定時間自動發送打卡請求，即使應用程序未運行也能正常工作',
+                      style: TextStyle(color: Colors.grey),
                     ),
-                  ),
-                  const SizedBox(height: 24),
-                  Card(
-                    child: Padding(
-                      padding: const EdgeInsets.all(16.0),
-                      child: Column(
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: [
-                          const Text(
-                            '注意事項:',
-                            style: TextStyle(fontWeight: FontWeight.bold),
-                          ),
-                          const SizedBox(height: 8),
-                          const Text('• 自動打卡只會在工作日運行'),
-                          const Text('• 需要設定正確的Webhook URL才能成功打卡'),
-                          const Text('• 如果該時間點已經手動打過卡，系統將不會重複打卡'),
-                          const Text('• 現在支持在後台運行，即使應用程序未開啟也能打卡'),
-                          const Text('• 若清除今天的打卡記錄，到達設定時間時系統會重新自動打卡'),
-                          const Text('• 自動打卡成功後會自動標記為今日已打卡，並發送通知提醒'),
-                          const SizedBox(height: 12),
-                          Container(
-                            padding: const EdgeInsets.all(8),
-                            decoration: BoxDecoration(
-                              color: Colors.blue.shade50,
-                              borderRadius: BorderRadius.circular(8),
+                    const SizedBox(height: 24),
+
+                    // 上班打卡設置
+                    const Text(
+                      '上班打卡',
+                      style:
+                          TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
+                    ),
+                    const SizedBox(height: 8),
+                    Card(
+                      child: Padding(
+                        padding: const EdgeInsets.all(16.0),
+                        child: Column(
+                          children: [
+                            SwitchListTile(
+                              title: const Text('啟用自動上班打卡'),
+                              value: _clockInEnabled,
+                              onChanged: (value) {
+                                setState(() {
+                                  _clockInEnabled = value;
+                                });
+                              },
                             ),
-                            child: Row(
-                              children: [
-                                const Icon(
-                                  Icons.info_outline, 
-                                  color: Colors.blue, 
-                                  size: 18,
+                            const Divider(),
+                            ListTile(
+                              title: const Text('上班打卡時間'),
+                              trailing: Text(
+                                _formatTimeOfDay(_clockInTime),
+                                style: const TextStyle(
+                                  fontSize: 16,
+                                  fontWeight: FontWeight.bold,
                                 ),
-                                const SizedBox(width: 8),
-                                const Expanded(
-                                  child: Text(
-                                    '在某些裝置上，系統省電模式可能會限制後台任務。若要確保功能正常運行，請考慮將本應用加入電池優化白名單。',
-                                    style: TextStyle(color: Colors.blue),
+                              ),
+                              onTap: _selectClockInTime,
+                              enabled: _clockInEnabled,
+                            ),
+                          ],
+                        ),
+                      ),
+                    ),
+                    const SizedBox(height: 24),
+
+                    // 下班打卡設置
+                    const Text(
+                      '下班打卡',
+                      style:
+                          TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
+                    ),
+                    const SizedBox(height: 8),
+                    Card(
+                      child: Padding(
+                        padding: const EdgeInsets.all(16.0),
+                        child: Column(
+                          children: [
+                            SwitchListTile(
+                              title: const Text('啟用自動下班打卡'),
+                              value: _clockOutEnabled,
+                              onChanged: (value) {
+                                setState(() {
+                                  _clockOutEnabled = value;
+                                });
+                              },
+                            ),
+                            const Divider(),
+                            ListTile(
+                              title: const Text('下班打卡時間'),
+                              trailing: Text(
+                                _formatTimeOfDay(_clockOutTime),
+                                style: const TextStyle(
+                                  fontSize: 16,
+                                  fontWeight: FontWeight.bold,
+                                ),
+                              ),
+                              onTap: _selectClockOutTime,
+                              enabled: _clockOutEnabled,
+                            ),
+                          ],
+                        ),
+                      ),
+                    ),
+                    const SizedBox(height: 24),
+                    Card(
+                      child: Padding(
+                        padding: const EdgeInsets.all(16.0),
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            const Text(
+                              '注意事項:',
+                              style: TextStyle(fontWeight: FontWeight.bold),
+                            ),
+                            const SizedBox(height: 8),
+                            const Text('• 自動打卡只會在工作日運行'),
+                            const Text('• 需要設定正確的Webhook URL才能成功打卡'),
+                            const Text('• 如果該時間點已經手動打過卡，系統將不會重複打卡'),
+                            const Text('• 現在支持在後台運行，即使應用程序未開啟也能打卡'),
+                            const Text('• 若清除今天的打卡記錄，到達設定時間時系統會重新自動打卡'),
+                            const Text('• 自動打卡成功後會自動標記為今日已打卡，並發送通知提醒'),
+                            const SizedBox(height: 12),
+                            Container(
+                              padding: const EdgeInsets.all(8),
+                              decoration: BoxDecoration(
+                                color: Colors.blue.shade50,
+                                borderRadius: BorderRadius.circular(8),
+                              ),
+                              child: Row(
+                                children: [
+                                  const Icon(
+                                    Icons.info_outline,
+                                    color: Colors.blue,
+                                    size: 18,
                                   ),
-                                ),
-                              ],
+                                  const SizedBox(width: 8),
+                                  const Expanded(
+                                    child: Text(
+                                      '在某些裝置上，系統省電模式可能會限制後台任務。若要確保功能正常運行，請考慮將本應用加入電池優化白名單。',
+                                      style: TextStyle(color: Colors.blue),
+                                    ),
+                                  ),
+                                ],
+                              ),
                             ),
-                          ),
-                        ],
+                          ],
+                        ),
                       ),
                     ),
-                  ),
-                  const SizedBox(height: 24),
-                  SizedBox(
-                    width: double.infinity,
-                    child: ElevatedButton(
-                      onPressed: _saveSettings,
-                      style: ElevatedButton.styleFrom(
-                        padding: const EdgeInsets.all(16),
-                        backgroundColor: Colors.blue,
-                        foregroundColor: Colors.white,
+                    const SizedBox(height: 24),
+                    SizedBox(
+                      width: double.infinity,
+                      child: ElevatedButton(
+                        onPressed: () async {
+                          await _saveSettings();
+                          if (context.mounted) {
+                            Navigator.of(context).pop(true);
+                          }
+                        },
+                        style: ElevatedButton.styleFrom(
+                          padding: const EdgeInsets.all(16),
+                          backgroundColor: Colors.blue,
+                          foregroundColor: Colors.white,
+                        ),
+                        child: const Text('保存設置'),
                       ),
-                      child: const Text('保存設置'),
                     ),
-                  ),
-                ],
+                  ],
+                ),
               ),
-            ),
+      ),
     );
   }
 } 


### PR DESCRIPTION
This commit introduces a confirmation dialog that prompts the user to save any unsaved changes in the Webhook,
 Auto Clock, and Notification settings pages before navigating back.

<img width="343" alt="Snipaste_2025-06-11_09-41-55" src="https://github.com/user-attachments/assets/64ad3dd8-9530-4218-8bea-c6ca050ea322" />
