### PR TITLE
fix: change periodic task to one-off for auto clock-in/out

### DIFF
--- a/lib/services/background_service.dart
+++ b/lib/services/background_service.dart
@@ -107,10 +107,10 @@ class BackgroundService {
       final initialDelay = clockInTime.difference(now);
 
       // 設置上班打卡的定期任務（每24小時一次）
-      await Workmanager().registerPeriodicTask(
+      await Workmanager().registerOneOffTask(
         clockInTaskName,
         clockInTaskName,
-        frequency: const Duration(hours: 24),
+        //frequency: const Duration(hours: 24),
         initialDelay: initialDelay,
         existingWorkPolicy: ExistingWorkPolicy.replace,
         tag: "clock_in",
@@ -150,10 +150,10 @@ class BackgroundService {
       final initialDelay = clockOutTime.difference(now);
 
       // 設置下班打卡的定期任務（每24小時一次）
-      await Workmanager().registerPeriodicTask(
+      await Workmanager().registerOneOffTask(
         clockOutTaskName,
         clockOutTaskName,
-        frequency: const Duration(hours: 24),
+        //frequency: const Duration(hours: 24),
         initialDelay: initialDelay,
         existingWorkPolicy: ExistingWorkPolicy.replace,
         tag: "clock_out",


### PR DESCRIPTION
本次提交將 Workmanager 中自動打卡和下班的註冊方式從 `registerPeriodicTask` 更改為 `registerOneOffTask`。

`frequency` 參數已被註解掉，因為它不適用於一次性任務。此變更可確保打卡/下班任務在計算出的 `initialDelay` 時被安排一次，而不是每 24 小時重複一次。